### PR TITLE
Print bindings for unfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ mkdir build && cd  build
 cmake ..
 
 #For mac, one need to enforce that we use the GCC compiler using:
-export CC=gcc-9
-export CXX=g++-9
+export CC=gcc-13
+export CXX=g++-13
 #and point to the correct version of flex and bison by adding
 #-DBISON_EXECUTABLE=/usr/local/opt/bison/bin/bison -DFLEX_EXECUTABLE=/usr/local/opt/flex/bin/flex
 #to cmake call

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -10,8 +10,6 @@
 
 #include <vector>
 #include <unordered_map>
-#include <iostream>
-#include <sstream>
 #include <sstream>
 
 #include "ColoredNetStructures.h"

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -23,7 +23,7 @@ namespace unfoldtacpn {
 
     public:
         ColoredPetriNetBuilder();
-        ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig);
+        ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig, const bool print_binding=false);
         virtual ~ColoredPetriNetBuilder();
         void parseNet(std::istream& istream);
 
@@ -82,6 +82,10 @@ namespace unfoldtacpn {
             return _pttransitionnames;
         }
 
+        const bool getPrintBindingStatus() const {
+            return _print_binding;
+        }
+
         void unfold(TAPNBuilderInterface& builder);
         void clear() { _sumPlacesNames.clear(); _pttransitionnames.clear(); _ptplacenames.clear(); }
     private:
@@ -98,6 +102,8 @@ namespace unfoldtacpn {
         std::map<uint32_t, std::vector<Colored::Arc>> _inhibitorArcs;
         ColorTypeMap _colors;
         double _time;
+
+        bool _print_binding;
 
         std::string arcToString(const Colored::Arc& arc) const;
         const std::string& findSumName(const std::string& id) const;

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -103,7 +103,7 @@ namespace unfoldtacpn {
         ColorTypeMap _colors;
         double _time;
 
-        bool _print_binding;
+        bool _print_binding = true;
 
         std::string arcToString(const Colored::Arc& arc) const;
         const std::string& findSumName(const std::string& id) const;

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -22,7 +22,7 @@ namespace unfoldtacpn {
         typedef std::unordered_map<std::string, std::vector<std::string>> PTTransitionMap;
 
     public:
-        ColoredPetriNetBuilder(const bool print_binding=false);
+        ColoredPetriNetBuilder(std::ostream* output_stream = nullptr);
         ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig);
         virtual ~ColoredPetriNetBuilder();
         void parseNet(std::istream& istream);
@@ -82,9 +82,6 @@ namespace unfoldtacpn {
             return _pttransitionnames;
         }
 
-        const bool getPrintBindingStatus() const {
-            return _print_binding;
-        }
 
         void unfold(TAPNBuilderInterface& builder);
         void clear() { _sumPlacesNames.clear(); _pttransitionnames.clear(); _ptplacenames.clear(); }
@@ -103,7 +100,7 @@ namespace unfoldtacpn {
         ColorTypeMap _colors;
         double _time;
 
-        bool _print_binding;
+        std::ostream* _output_stream;
 
         std::string arcToString(const Colored::Arc& arc) const;
         const std::string& findSumName(const std::string& id) const;

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -10,6 +10,7 @@
 
 #include <vector>
 #include <unordered_map>
+#include <iostream>
 
 #include "ColoredNetStructures.h"
 #include "../TAPNBuilderInterface.h"

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -23,7 +23,7 @@ namespace unfoldtacpn {
 
     public:
         ColoredPetriNetBuilder(const bool print_binding=false);
-        ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig, const bool print_binding=false);
+        ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig);
         virtual ~ColoredPetriNetBuilder();
         void parseNet(std::istream& istream);
 

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -11,6 +11,8 @@
 #include <vector>
 #include <unordered_map>
 #include <iostream>
+#include <sstream>
+#include <sstream>
 
 #include "ColoredNetStructures.h"
 #include "../TAPNBuilderInterface.h"

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -22,8 +22,8 @@ namespace unfoldtacpn {
         typedef std::unordered_map<std::string, std::vector<std::string>> PTTransitionMap;
 
     public:
-        ColoredPetriNetBuilder(const bool print_binding=true);
-        ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig, const bool print_binding=true);
+        ColoredPetriNetBuilder(const bool print_binding=false);
+        ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig, const bool print_binding=false);
         virtual ~ColoredPetriNetBuilder();
         void parseNet(std::istream& istream);
 

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -22,7 +22,7 @@ namespace unfoldtacpn {
         typedef std::unordered_map<std::string, std::vector<std::string>> PTTransitionMap;
 
     public:
-        ColoredPetriNetBuilder(std::ostream* output_stream = nullptr);
+        ColoredPetriNetBuilder(std::stringstream &output_stream = nullptr);
         ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig);
         virtual ~ColoredPetriNetBuilder();
         void parseNet(std::istream& istream);
@@ -100,7 +100,7 @@ namespace unfoldtacpn {
         ColorTypeMap _colors;
         double _time;
 
-        std::ostream* _output_stream;
+        std::stringstream& _output_stream;
 
         std::string arcToString(const Colored::Arc& arc) const;
         const std::string& findSumName(const std::string& id) const;

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -22,7 +22,7 @@ namespace unfoldtacpn {
         typedef std::unordered_map<std::string, std::vector<std::string>> PTTransitionMap;
 
     public:
-        ColoredPetriNetBuilder(std::stringstream &output_stream = nullptr);
+        ColoredPetriNetBuilder(std::stringstream &output_stream, const bool print_bindings=false);
         ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig);
         virtual ~ColoredPetriNetBuilder();
         void parseNet(std::istream& istream);
@@ -101,6 +101,7 @@ namespace unfoldtacpn {
         double _time;
 
         std::stringstream& _output_stream;
+        const bool _print_bindings;
 
         std::string arcToString(const Colored::Arc& arc) const;
         const std::string& findSumName(const std::string& id) const;

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -22,7 +22,7 @@ namespace unfoldtacpn {
         typedef std::unordered_map<std::string, std::vector<std::string>> PTTransitionMap;
 
     public:
-        ColoredPetriNetBuilder();
+        ColoredPetriNetBuilder(const bool print_binding=true);
         ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig, const bool print_binding=true);
         virtual ~ColoredPetriNetBuilder();
         void parseNet(std::istream& istream);
@@ -103,7 +103,7 @@ namespace unfoldtacpn {
         ColorTypeMap _colors;
         double _time;
 
-        bool _print_binding = true;
+        bool _print_binding;
 
         std::string arcToString(const Colored::Arc& arc) const;
         const std::string& findSumName(const std::string& id) const;

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -23,7 +23,7 @@ namespace unfoldtacpn {
 
     public:
         ColoredPetriNetBuilder();
-        ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig, const bool print_binding=false);
+        ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig, const bool print_binding=true);
         virtual ~ColoredPetriNetBuilder();
         void parseNet(std::istream& istream);
 

--- a/include/Colored/ColoredPetriNetBuilder.h
+++ b/include/Colored/ColoredPetriNetBuilder.h
@@ -22,7 +22,7 @@ namespace unfoldtacpn {
         typedef std::unordered_map<std::string, std::vector<std::string>> PTTransitionMap;
 
     public:
-        ColoredPetriNetBuilder(std::stringstream &output_stream, const bool print_bindings=false);
+        ColoredPetriNetBuilder(std::stringstream *output_stream = nullptr);
         ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig);
         virtual ~ColoredPetriNetBuilder();
         void parseNet(std::istream& istream);
@@ -100,9 +100,8 @@ namespace unfoldtacpn {
         ColorTypeMap _colors;
         double _time;
 
-        std::stringstream& _output_stream;
-        const bool _print_bindings;
-
+        std::stringstream* _output_stream;
+        
         std::string arcToString(const Colored::Arc& arc) const;
         const std::string& findSumName(const std::string& id) const;
         const std::string& findSumName(uint32_t id) const { return findSumName(_places[id].name); }

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -198,7 +198,7 @@ namespace unfoldtacpn {
         }
 
         if (_output_stream) {
-            (*_output_stream) << "Printing bindings for each unfolded transition.\n";
+            (*_output_stream) << "\n BINDINGS FOR EACH UNFOLDED TRANSITION:\n";
             (*_output_stream) << "<bindings>\n";
         }
 

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -16,7 +16,7 @@ namespace unfoldtacpn {
     ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::ostream* output_stream):
     _output_stream(output_stream) 
     {
-    std::cout << "Outstream is " << output_stream ? "not-null" : null << "\n";
+    std::cout << "Outstream is " << output_stream ? "not-null" : "null" << "\n";
     }
 
     ColoredPetriNetBuilder::ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig)

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -7,7 +7,6 @@
 
 #include <chrono>
 #include <tuple>
-#include <iostream>
 #include <sstream>
 
 #include "Colored/ColoredPetriNetBuilder.h"

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -303,7 +303,7 @@ namespace unfoldtacpn {
             //if(!gen.isInitial())
             name += "__" + std::to_string(i++);
 
-            // Print bindings for each transition if output stream is not null
+            // Print bindings for each transition if output stream exists
             if (_output_stream) {     
                 (*_output_stream) << "   <transition id=\"" << name << "\">\n";    
                 for(auto const &var: b) {

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -198,7 +198,7 @@ namespace unfoldtacpn {
         }
 
         if (_output_stream) {
-            (*_output_stream) << "\nBINDINGS FOR EACH UNFOLDED TRANSITION:\n";
+            (*_output_stream) << "\nBINDINGS FOR EACH UNFOLDED TRANSITION\n";
             (*_output_stream) << "<bindings>\n";
         }
 

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -13,7 +13,10 @@
 #include "errorcodes.h"
 
 namespace unfoldtacpn {
-    ColoredPetriNetBuilder::ColoredPetriNetBuilder() {
+    ColoredPetriNetBuilder::ColoredPetriNetBuilder(const bool print_binding):
+    _print_binding(print_binding) 
+    {
+    
     }
 
     ColoredPetriNetBuilder::ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig, const bool print_binding)

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -285,7 +285,7 @@ namespace unfoldtacpn {
         auto transitionPos = _transitionlocations[transitionId];
         size_t i = 0;
         for (auto& b : gen) {
-            std:cout << "\n Unfolded transition: " << transition.name;
+            std::cout << "\n Unfolded transition: " << transition.name;
             std::string name = transition.name;
             if(!gen.isInitial())
                 name += "__" + std::to_string(i++);

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <tuple>
 #include <iostream>
+#include <sstream>
 
 #include "Colored/ColoredPetriNetBuilder.h"
 #include "PetriParse/PNMLParser.h"

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -193,8 +193,17 @@ namespace unfoldtacpn {
             unfoldPlace(builder, place);
         }
 
+        if (getPrintBindingStatus()) {
+            std::cout << "Printing bindings for each unfolded transition.\n";
+            std::cout << "<bindings>\n";
+        }
+
         for (auto& transition : _transitions) {
             unfoldTransition(builder, transition);
+        }
+
+        if (getPrintBindingStatus()) {
+            std::cout << "</bindings>\n";
         }
 
         auto end = std::chrono::high_resolution_clock::now();
@@ -290,12 +299,15 @@ namespace unfoldtacpn {
             //if(!gen.isInitial())
             name += "__" + std::to_string(i++);
 
-            if (getPrintBindingStatus()) {
-            std::cout << "Unfolded transition: " << name << " binding:";
-            for (const auto &var: b) {
-                std::cout << "   " << var.first << " -> " << var.second->getColorName();
-            }
-            std::cout << "\n";
+            // Print bindings for each transition
+            if (getPrintBindingStatus()) {     
+                std::cout << "   <transition id=\"" << name << "\">\n";    
+                for(auto const &var: b) {
+                    std::cout << "      <variable id=\"" << var.first << "\">\n";
+                    std::cout << "         <color>" << var.second->getColorName() << "</color>\n";
+                    std::cout << "      </variable>\n";
+                }
+                std::cout << "   </transition>\n";
             }
 
             builder.addTransition(name, transition.player, transition.urgent, std::get<0>(transitionPos), std::get<1>(transitionPos) + offset);

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -196,7 +196,7 @@ namespace unfoldtacpn {
             unfoldPlace(builder, place);
         }
 
-        if (!_output_stream)) {
+        if (_output_stream) {
             std::cout << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
         }
@@ -205,7 +205,7 @@ namespace unfoldtacpn {
             unfoldTransition(builder, transition);
         }
 
-        if (_output_stream)) {
+        if (_output_stream) {
             std::cout << "</bindings>\n";
         }
 
@@ -303,7 +303,7 @@ namespace unfoldtacpn {
             name += "__" + std::to_string(i++);
 
             // Print bindings for each transition if output stream is not null
-            if (_output_stream)) {     
+            if (_output_stream) {     
                 std::cout << "   <transition id=\"" << name << "\">\n";    
                 for(auto const &var: b) {
                     std::cout << "      <variable id=\"" << var.first << "\">\n";

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -196,7 +196,7 @@ namespace unfoldtacpn {
             unfoldPlace(builder, place);
         }
 
-        if (_output_stream)) {
+        if (!_output_stream)) {
             std::cout << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
         }

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -197,7 +197,7 @@ namespace unfoldtacpn {
         }
 
         if (_output_stream) {
-            std::cout << "Printing bindings for each unfolded transition.\n";
+            *_output_stream << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
         }
 

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -16,7 +16,7 @@ namespace unfoldtacpn {
     ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::ostream* output_stream):
     _output_stream(output_stream) 
     {
-    
+    std::cout << "Outstream is " << output_stream ? "not-null" : null << "\n";
     }
 
     ColoredPetriNetBuilder::ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig)

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -288,12 +288,15 @@ namespace unfoldtacpn {
            
             std::string name = transition.name;
             //if(!gen.isInitial())
-                name += "__" + std::to_string(i++);
-             std::cout << "Unfolded transition: " << name << " binding:";
+            name += "__" + std::to_string(i++);
+
+            if (getPrintBindingStatus()) {
+            std::cout << "Unfolded transition: " << name << " binding:";
             for (const auto &var: b) {
                 std::cout << "   " << var.first << " -> " << var.second->getColorName();
             }
             std::cout << "\n";
+            }
 
             builder.addTransition(name, transition.player, transition.urgent, std::get<0>(transitionPos), std::get<1>(transitionPos) + offset);
             _pttransitionnames[transition.name].push_back(name);
@@ -471,7 +474,7 @@ namespace unfoldtacpn {
         return !arc.input ? "(" + _transitions[arc.transition].name + ", " + _places[arc.place].name + ")" :
                "(" + _places[arc.place].name + ", " + _transitions[arc.transition].name + ")";
     }
-
+  
     BindingGenerator::Iterator::Iterator(BindingGenerator* generator)
             : _generator(generator)
     {

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -199,7 +199,7 @@ namespace unfoldtacpn {
         //if (!_output_stream)) {
             std::cout << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
-        //}
+    }
 
         for (auto& transition : _transitions) {
             unfoldTransition(builder, transition);

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -289,10 +289,11 @@ namespace unfoldtacpn {
             std::string name = transition.name;
             if(!gen.isInitial())
                 name += "__" + std::to_string(i++);
-             std::cout << "Unfolded transition: " << name << "\n";
+             std::cout << "Unfolded transition: " << name << " binding:";
             for (const auto var: b) {
-                std::cout << "Variable: " << var.first << " -> " << var.second->getColorName();
+                std::cout << "   " << var.first << " -> " << var.second->getColorName();
             }
+            std::cout << "\n";
 
             builder.addTransition(name, transition.player, transition.urgent, std::get<0>(transitionPos), std::get<1>(transitionPos) + offset);
             _pttransitionnames[transition.name].push_back(name);

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -13,14 +13,11 @@
 #include "errorcodes.h"
 
 namespace unfoldtacpn {
-    ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::stringstream &output_stream):
-    _output_stream(output_stream) 
+    ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::stringstream &output_stream, const bool print_bindings):
+    _output_stream(output_stream),
+    _print_bindings(print_bindings)
     {
-    if (output_stream) {
-        std::cout << "Output stream is not-empty\n";
-    } else {
-        std::cout << "Output stream i empty\n";
-    }
+    
     }
 
     ColoredPetriNetBuilder::ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig)
@@ -200,7 +197,7 @@ namespace unfoldtacpn {
             unfoldPlace(builder, place);
         }
 
-        if (_output_stream) {
+        if (_print_bindings) {
             std::cout << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
         }
@@ -209,7 +206,7 @@ namespace unfoldtacpn {
             unfoldTransition(builder, transition);
         }
 
-        if (_output_stream) {
+        if (_print_bindings) {
             std::cout << "</bindings>\n";
         }
 
@@ -307,7 +304,7 @@ namespace unfoldtacpn {
             name += "__" + std::to_string(i++);
 
             // Print bindings for each transition if output stream is not null
-            if (_output_stream) {     
+            if (_print_bindings) {     
                 std::cout << "   <transition id=\"" << name << "\">\n";    
                 for(auto const &var: b) {
                     std::cout << "      <variable id=\"" << var.first << "\">\n";

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <tuple>
+#include <iostream>
 
 #include "Colored/ColoredPetriNetBuilder.h"
 #include "PetriParse/PNMLParser.h"
@@ -197,7 +198,7 @@ namespace unfoldtacpn {
         }
 
         if (_output_stream) {
-            std::cout << "Printing bindings for each unfolded transition.\n";
+            (*_output_stream) << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
         }
 

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -196,10 +196,10 @@ namespace unfoldtacpn {
             unfoldPlace(builder, place);
         }
 
-        //if (!_output_stream)) {
+        if (!_output_stream)) {
             std::cout << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
-    }
+        }
 
         for (auto& transition : _transitions) {
             unfoldTransition(builder, transition);

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -198,7 +198,7 @@ namespace unfoldtacpn {
         }
 
         if (_output_stream) {
-            (*_output_stream) << "\n BINDINGS FOR EACH UNFOLDED TRANSITION:\n";
+            (*_output_stream) << "\nBINDINGS FOR EACH UNFOLDED TRANSITION:\n";
             (*_output_stream) << "<bindings>\n";
         }
 

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -197,7 +197,7 @@ namespace unfoldtacpn {
         }
 
         if (_output_stream) {
-            _output_stream << "Printing bindings for each unfolded transition.\n";
+            (*_output_stream) << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
         }
 

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -13,7 +13,7 @@
 #include "errorcodes.h"
 
 namespace unfoldtacpn {
-    ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::ostream* output_stream):
+    ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::stringstream &output_stream):
     _output_stream(output_stream) 
     {
     if (output_stream) {

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -285,10 +285,15 @@ namespace unfoldtacpn {
         auto transitionPos = _transitionlocations[transitionId];
         size_t i = 0;
         for (auto& b : gen) {
-            std::cout << "\n Unfolded transition: " << transition.name;
+           
             std::string name = transition.name;
             if(!gen.isInitial())
                 name += "__" + std::to_string(i++);
+             std::cout << "Unfolded transition: " << name << "\n";
+            for (const auto var: b) {
+                std::cout << "Variable: " << var.first << " -> " << var.second->getColorName();
+            }
+
             builder.addTransition(name, transition.player, transition.urgent, std::get<0>(transitionPos), std::get<1>(transitionPos) + offset);
             _pttransitionnames[transition.name].push_back(name);
             for (auto& arc : transition.arcs) {

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -16,10 +16,10 @@ namespace unfoldtacpn {
     ColoredPetriNetBuilder::ColoredPetriNetBuilder() {
     }
 
-    ColoredPetriNetBuilder::ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig)
+    ColoredPetriNetBuilder::ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig, const print_binding)
     : _placenames(orig._placenames), _transitionnames(orig._transitionnames),
        _placelocations(orig._placelocations), _transitionlocations(orig._transitionlocations),
-       _transitions(orig._transitions), _places(orig._places)
+       _transitions(orig._transitions), _places(orig._places), _print_binding(print_binding)
     {
 
     }

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -13,7 +13,7 @@
 #include "errorcodes.h"
 
 namespace unfoldtacpn {
-    ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::stringstream &output_stream, const bool print_bindings = false):
+    ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::stringstream &output_stream, const bool print_bindings):
     _output_stream(output_stream),
     _print_bindings(print_bindings)
     {

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -13,7 +13,7 @@
 #include "errorcodes.h"
 
 namespace unfoldtacpn {
-    ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::stringstream &output_stream, const bool print_bindings):
+    ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::stringstream &output_stream, const bool print_bindings = false):
     _output_stream(output_stream),
     _print_bindings(print_bindings)
     {

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -287,10 +287,10 @@ namespace unfoldtacpn {
         for (auto& b : gen) {
            
             std::string name = transition.name;
-            if(!gen.isInitial())
+            //if(!gen.isInitial())
                 name += "__" + std::to_string(i++);
              std::cout << "Unfolded transition: " << name << " binding:";
-            for (const auto var: b) {
+            for (const auto &var: b) {
                 std::cout << "   " << var.first << " -> " << var.second->getColorName();
             }
             std::cout << "\n";

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -197,7 +197,7 @@ namespace unfoldtacpn {
         }
 
         if (_output_stream) {
-            (*_output_stream) << "Printing bindings for each unfolded transition.\n";
+            std::cout << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
         }
 

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -197,7 +197,7 @@ namespace unfoldtacpn {
         }
 
         if (_output_stream) {
-            *_output_stream << "Printing bindings for each unfolded transition.\n";
+            _output_stream << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
         }
 

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -16,7 +16,7 @@ namespace unfoldtacpn {
     ColoredPetriNetBuilder::ColoredPetriNetBuilder() {
     }
 
-    ColoredPetriNetBuilder::ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig, const print_binding)
+    ColoredPetriNetBuilder::ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig, const bool print_binding)
     : _placenames(orig._placenames), _transitionnames(orig._transitionnames),
        _placelocations(orig._placelocations), _transitionlocations(orig._transitionlocations),
        _transitions(orig._transitions), _places(orig._places), _print_binding(print_binding)

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -196,10 +196,10 @@ namespace unfoldtacpn {
             unfoldPlace(builder, place);
         }
 
-        if (!_output_stream)) {
+        //if (!_output_stream)) {
             std::cout << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
-        }
+        //}
 
         for (auto& transition : _transitions) {
             unfoldTransition(builder, transition);

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -13,9 +13,8 @@
 #include "errorcodes.h"
 
 namespace unfoldtacpn {
-    ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::stringstream &output_stream, const bool print_bindings):
-    _output_stream(output_stream),
-    _print_bindings(print_bindings)
+    ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::stringstream *output_stream):
+    _output_stream(output_stream)
     {
     
     }
@@ -197,7 +196,7 @@ namespace unfoldtacpn {
             unfoldPlace(builder, place);
         }
 
-        if (_print_bindings) {
+        if (_output_stream) {
             std::cout << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
         }
@@ -206,7 +205,7 @@ namespace unfoldtacpn {
             unfoldTransition(builder, transition);
         }
 
-        if (_print_bindings) {
+        if (_output_stream) {
             std::cout << "</bindings>\n";
         }
 
@@ -304,7 +303,7 @@ namespace unfoldtacpn {
             name += "__" + std::to_string(i++);
 
             // Print bindings for each transition if output stream is not null
-            if (_print_bindings) {     
+            if (_output_stream) {     
                 std::cout << "   <transition id=\"" << name << "\">\n";    
                 for(auto const &var: b) {
                     std::cout << "      <variable id=\"" << var.first << "\">\n";

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -199,7 +199,7 @@ namespace unfoldtacpn {
 
         if (_output_stream) {
             (*_output_stream) << "Printing bindings for each unfolded transition.\n";
-            std::cout << "<bindings>\n";
+            (*_output_stream) << "<bindings>\n";
         }
 
         for (auto& transition : _transitions) {
@@ -207,7 +207,7 @@ namespace unfoldtacpn {
         }
 
         if (_output_stream) {
-            std::cout << "</bindings>\n";
+            (*_output_stream) << "</bindings>\n";
         }
 
         auto end = std::chrono::high_resolution_clock::now();
@@ -305,13 +305,13 @@ namespace unfoldtacpn {
 
             // Print bindings for each transition if output stream is not null
             if (_output_stream) {     
-                std::cout << "   <transition id=\"" << name << "\">\n";    
+                (*_output_stream) << "   <transition id=\"" << name << "\">\n";    
                 for(auto const &var: b) {
-                    std::cout << "      <variable id=\"" << var.first << "\">\n";
-                    std::cout << "         <color>" << var.second->getColorName() << "</color>\n";
-                    std::cout << "      </variable>\n";
+                    (*_output_stream) << "      <variable id=\"" << var.first << "\">\n";
+                    (*_output_stream) << "         <color>" << var.second->getColorName() << "</color>\n";
+                    (*_output_stream) << "      </variable>\n";
                 }
-                std::cout << "   </transition>\n";
+                (*_output_stream) << "   </transition>\n";
             }
 
             builder.addTransition(name, transition.player, transition.urgent, std::get<0>(transitionPos), std::get<1>(transitionPos) + offset);

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -285,6 +285,7 @@ namespace unfoldtacpn {
         auto transitionPos = _transitionlocations[transitionId];
         size_t i = 0;
         for (auto& b : gen) {
+            std:cout << "\n Unfolded transition: " << transition.name;
             std::string name = transition.name;
             if(!gen.isInitial())
                 name += "__" + std::to_string(i++);

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -13,8 +13,8 @@
 #include "errorcodes.h"
 
 namespace unfoldtacpn {
-    ColoredPetriNetBuilder::ColoredPetriNetBuilder(const bool print_binding):
-    _print_binding(print_binding) 
+    ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::ostream* output_stream):
+    _output_stream(output_stream) 
     {
     
     }
@@ -196,7 +196,7 @@ namespace unfoldtacpn {
             unfoldPlace(builder, place);
         }
 
-        if (getPrintBindingStatus()) {
+        if (_output_stream)) {
             std::cout << "Printing bindings for each unfolded transition.\n";
             std::cout << "<bindings>\n";
         }
@@ -205,7 +205,7 @@ namespace unfoldtacpn {
             unfoldTransition(builder, transition);
         }
 
-        if (getPrintBindingStatus()) {
+        if (_output_stream)) {
             std::cout << "</bindings>\n";
         }
 
@@ -302,8 +302,8 @@ namespace unfoldtacpn {
             //if(!gen.isInitial())
             name += "__" + std::to_string(i++);
 
-            // Print bindings for each transition
-            if (getPrintBindingStatus()) {     
+            // Print bindings for each transition if output stream is not null
+            if (_output_stream)) {     
                 std::cout << "   <transition id=\"" << name << "\">\n";    
                 for(auto const &var: b) {
                     std::cout << "      <variable id=\"" << var.first << "\">\n";

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -19,10 +19,10 @@ namespace unfoldtacpn {
     
     }
 
-    ColoredPetriNetBuilder::ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig, const bool print_binding)
+    ColoredPetriNetBuilder::ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig)
     : _placenames(orig._placenames), _transitionnames(orig._transitionnames),
        _placelocations(orig._placelocations), _transitionlocations(orig._transitionlocations),
-       _transitions(orig._transitions), _places(orig._places), _print_binding(print_binding)
+       _transitions(orig._transitions), _places(orig._places)
     {
 
     }

--- a/src/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/Colored/ColoredPetriNetBuilder.cpp
@@ -16,7 +16,11 @@ namespace unfoldtacpn {
     ColoredPetriNetBuilder::ColoredPetriNetBuilder(std::ostream* output_stream):
     _output_stream(output_stream) 
     {
-    std::cout << "Outstream is " << output_stream ? "not-null" : "null" << "\n";
+    if (output_stream) {
+        std::cout << "Output stream is not-empty\n";
+    } else {
+        std::cout << "Output stream i empty\n";
+    }
     }
 
     ColoredPetriNetBuilder::ColoredPetriNetBuilder(const ColoredPetriNetBuilder& orig)


### PR DESCRIPTION
added the possibility to print bindings for the unfolder by passing true/false to the ColoredPetriNetBuilder constructer